### PR TITLE
Add principal variation search

### DIFF
--- a/src/evaluate/simple_evaluator.rs
+++ b/src/evaluate/simple_evaluator.rs
@@ -9,7 +9,7 @@ use crate::search::Score;
 pub struct SimpleEvaluator;
 
 impl SimpleEvaluator {
-    const KING_VALUE: Score = Score::MAX / 2;
+    const KING_VALUE: Score = 0; // Kings should always cancel each other out, so no need to count
     const QUEEN_VALUE: Score = 900;
     const ROOK_VALUE: Score = 500;
     const BISHOP_VALUE: Score = 300;


### PR DESCRIPTION
This search will constrain the bounds of the search to attempt to look deeper in the principal variation. This should frequently mean we can look deeper without having to sacrifice accuracy.

Bench: 8361479