### PR TITLE
Add killer move heuristic

### DIFF
--- a/src/board/ply.rs
+++ b/src/board/ply.rs
@@ -84,6 +84,10 @@ impl Ply {
         self.promoted_to.is_some()
     }
 
+    pub const fn is_quiet(&self) -> bool {
+        !self.is_capture() && !self.is_promotion()
+    }
+
     pub const fn is_en_passant(&self) -> bool {
         self.en_passant
     }

--- a/src/search/info.rs
+++ b/src/search/info.rs
@@ -1,6 +1,9 @@
 use crate::board::Ply;
 
-use super::Score;
+use super::{Depth, Score};
+
+pub const MAX_KILLERS: usize = 2;
+pub type KillerList = [[Option<Ply>; MAX_KILLERS]; Depth::MAX as usize];
 
 /// Information about the search process.
 /// Usually displayed in the uci `info` log.
@@ -32,6 +35,8 @@ pub struct Info {
     pub best_move: Option<Ply>,
     pub best_score: Option<Score>,
     pub nodes: u64,
+    pub depth: Depth,
+    pub killers: KillerList,
 }
 
 impl Info {
@@ -41,6 +46,8 @@ impl Info {
             best_move: None,
             best_score: None,
             nodes: 0,
+            depth: 0,
+            killers: [[None; MAX_KILLERS]; Depth::MAX as usize],
         }
     }
 }


### PR DESCRIPTION
Attempts to search moves that previuosly were known to be good at the same depth as the current search. If a move was good, there are typically only a few moves that meet the threat and maintain equality. This greatly restricts the search tree because our opponent must meet our threat or lose.

Bench: 7153794