### PR TITLE
Qsearch

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -77,10 +77,15 @@ impl Board {
     /// let movelist = board.get_all_moves(Square::new("a2"));
     /// ```
     pub fn get_legal_moves(&mut self) -> Vec<Ply> {
-        self.get_all_moves()
-            .into_iter()
-            .filter(|mv| self.is_legal_move(*mv).is_ok())
-            .collect()
+        let mut moves = self.get_all_moves();
+        moves.retain(|mv| self.is_legal_move(*mv).is_ok());
+        moves
+    }
+
+    pub fn get_filtered_moves(&self, predicate: fn(&Ply) -> bool) -> Vec<Ply> {
+        let mut moves = self.get_all_moves();
+        moves.retain(predicate);
+        moves
     }
 
     /// Returns a boolean representing whether or not a given move is legal

--- a/src/search.rs
+++ b/src/search.rs
@@ -315,7 +315,7 @@ impl Search {
         evaluator: &impl Evaluator,
         alpha_start: Score,
         beta_start: Score,
-        depth: Depth,
+        mut depth: Depth,
         start: Instant,
     ) -> Score {
         if !self.is_running() || self.limits_exceeded(start) {
@@ -350,6 +350,10 @@ impl Search {
                     return entry.score;
                 }
             }
+        }
+
+        if self.board.is_in_check(self.board.current_turn) {
+            depth += 1; // Get out of check before entering quiescence
         }
 
         if depth == 0 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -656,8 +656,12 @@ impl Search {
 
         for _ in 0..length {
             if let Some(entry) = tt.get(&self.original_board.zkey) {
-                plys.push(entry.best_ply);
-                self.original_board.make_move(entry.best_ply);
+                let best_ply = entry.best_ply;
+                if !self.original_board.is_legal_move(best_ply).is_ok() {
+                    break;
+                }
+                plys.push(best_ply);
+                self.original_board.make_move(best_ply);
             } else {
                 break;
             }


### PR DESCRIPTION
Quiescence search avoids the horizon effect. That is, the fact that we have to stop searching somewhere, but some moves - like captures - radically change the evaluation. Qsearch is a way of continuing the search until every line ends in a quiet move which is much more likely to not have radical evaluation changes on the next move. This way, we're not falsely evaluating a position as good for us just because we captured a pawn with our queen, only to realize that we're losing our queen next move

Bench: 13749273