### PR TITLE
Fix killers overflow

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -98,10 +98,16 @@ impl Board {
     /// assert!(!board.is_legal_move(ply));
     /// ```
     pub fn is_legal_move(&mut self, ply: Ply) -> Result<Ply, &'static str> {
+        if ply.piece == Kind::King(ply.piece.get_color())
+            && self.is_square_attacked(ply.dest, ply.piece.get_color())
+        {
+            return Err("Move is not valid. The king would be in check.");
+        }
         self.make_move(ply);
-        if self.is_in_check(self.current_turn.opposite()) {
+        if self.is_in_check(ply.piece.get_color()) {
             self.unmake_move();
-            return Err("Move is not valid. The move would leave the king in check.");
+
+            return Err("Move is not valid. The king would be in check.");
         }
         self.unmake_move();
 
@@ -554,6 +560,27 @@ impl Board {
         self.bitboards.get_piece_kind(square)
     }
 
+    /// Returns a `bool` indicating if the square is attacked by the specified color
+    ///
+    /// # Arguments
+    ///
+    /// * `square` - The square to check for attacks
+    /// * `attacking_color` - The color of the attacking pieces
+    ///
+    /// # Examples
+    /// ```
+    /// let board = BoardBuilder::construct_starting_board().build();
+    /// assert!(!board.is_square_attacked(Square::new("a8"), Color::White));
+    /// assert!(board.is_square_attacked(Square::new("a3"), Color::White));
+    /// ```
+    pub fn is_square_attacked(&self, square: Square, attacking_color: Color) -> bool {
+        let attacks = self.get_attacked_squares(attacking_color);
+
+        let square_pos = Bitboard::from(square);
+
+        !(square_pos & attacks).is_empty()
+    }
+
     /// Returns a boolean representing whether or not the current side is in check
     ///
     /// # Examples
@@ -584,7 +611,6 @@ impl Board {
     ///
     /// let attacked_squares = board.get_attacked_squares(Color::White);
     /// ```
-    #[allow(clippy::literal_string_with_formatting_args)]
     fn get_attacked_squares(&self, color: Color) -> Bitboard {
         let attacking_pieces = match color {
             Color::White => self.bitboards.black_pieces,
@@ -599,7 +625,7 @@ impl Board {
 
             let piece = self
                 .get_piece(Square::from(square))
-                .expect("No piece found at {square} where bitboard claimed piece was!");
+                .expect("No piece found at square where bitboard claimed piece was!");
 
             attacks |= piece.get_attacks(Square::from(square), self);
         }
@@ -607,6 +633,8 @@ impl Board {
         attacks
     }
 
+    // position startpos moves b1a3 d7d5 a1b1 b8c6 b1a1 e7e5 g1f3 e5e4 f3g1 f8a3 b2a3 d8f6 a1b1 b7b6 c1b2 c6d4 e2e3 c8g4 d1g4 h7h5 g4d1 f6g5 e3d4 g8h6 b1a1 a7a6 d1c1 g5f5 a1b1 a8a7 g1h3 g7g6 c1d1 b6b5 h3g1 e8d8 d1e2 f5g4 e2g4 h5g4 b1a1 h8e8 g2g3 d8d7 a1b1 h6f5 b1d1 d7c6 d1a1 a7a8 a1c1 c6b7 c1b1 a8d8 e1d1 c7c6 b1c1 a6a5 d1e1 b5b4 a3b4 a5b4 c1a1 b7b6 a1b1 d8a8 f1e2 b6c7 e2g4 a8a2 g4f5 g6f5 e1d1 a2a8 d1c1 e8d8 c2c3 b4b3 c1d1 d8e8 d1e1 f5f4 g3f4 e8h8 e1f1 f7f5 g1e2 c7b6 b2c1 b6c7 b1b3 a8a1 f1e1 h8g8 h2h3 g8g2 e1f1 g2g8 h1g1 a1a8 g1g8 a8g8 c1b2 g8h8 f1g2 c7d6 b2a1 h8g8 e2g3 g8g7 f2f3 d6e6 f3e4 d5e4 b3a3 g7g6 a3a5 e6d7 a5f5 g6g7 f5e5 d7d8 e5e4 d8d7 d2d3 g7g6 a1b2 g6g7 b2c1 g7g6 c1d2 g6g8 d2e1 g8a8 e1f2 a8b8 g3e2 b8g8 g2f1 g8h8 e2g1 h8b8 f1e2 b8b2 e2e1 d7c7 g1f3 b2b1 e1d2 b1a1 c3c4 a1a2 d2e3 c7b6 e4e6 a2a1 f3e5 a1c1 e5c6 c1d1 h3h4 b6c7 d4d5 d1f1 f2g3 f1g1 e3f2 g1a1 e6e7 c7d6 f4f5 d6c5 f2g2 a1b1 e7d7 b1b2 g3f2 b2f2 g2f2 c5b6 f2g1 b6c5 d7b7 c5d6 f5f6 d6c5 f6f7 c5d6
+    // go wtime 18470 btime 26880 winc 2000 binc 2000
     /// Returns a `CastlingStatus` representing whether or not the current `kind` of castling is availiable
     ///
     /// # Arguments

--- a/src/search.rs
+++ b/src/search.rs
@@ -352,8 +352,11 @@ impl Search {
             }
         }
 
+        // Get out of check before entering quiescence
         if self.board.is_in_check(self.board.current_turn) {
-            depth += 1; // Get out of check before entering quiescence
+            // Since this is called from alpha_beta_start, depth will always be at least (Depth::MAX - 1).
+            // However, if we add more extensions, we need to be concerned with overflow in the future.
+            depth += 1;
         }
 
         if depth == 0 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -545,8 +545,23 @@ impl Search {
     /// let limits_exceeded = search.check_limits();
     /// ```
     fn limits_exceeded(&self, start: Instant) -> bool {
+        if self.info.depth == Depth::MAX {
+            return true;
+        }
         if let Some(nodes) = self.limits.nodes {
             if self.info.nodes >= nodes {
+                self.running.store(false, Ordering::Relaxed);
+                return true;
+            }
+        }
+        if let Some(depth) = self.limits.depth {
+            if self.info.depth >= depth {
+                self.running.store(false, Ordering::Relaxed);
+                return true;
+            }
+        }
+        if let Some(movetime) = self.limits.movetime {
+            if start.elapsed().as_millis() >= movetime {
                 self.running.store(false, Ordering::Relaxed);
                 return true;
             }
@@ -657,7 +672,7 @@ impl Search {
         for _ in 0..length {
             if let Some(entry) = tt.get(&self.original_board.zkey) {
                 let best_ply = entry.best_ply;
-                if !self.original_board.is_legal_move(best_ply).is_ok() {
+                if self.original_board.is_legal_move(best_ply).is_err() {
                     break;
                 }
                 plys.push(best_ply);
@@ -785,6 +800,48 @@ mod tests {
         let mut search = Search::new(&board, None);
         let best_move = search.alpha_beta_start(&SimpleEvaluator, 5, Instant::now());
         assert_eq!(best_move, Ply::default());
+    }
+
+    /// Designed to catch bug where we access the killer table set on a previous search out of bounds because we're searching to max depth
+    #[test]
+    fn test_mate_in_2() {
+        let mut board = Board::from_fen("8/1R6/2N2P2/2kP4/2P4P/3P4/8/6K1 w - - 1 94");
+        let mut search = Search::new(&board, None);
+        search.search(&SimpleEvaluator, Some(6));
+        let search_move = search
+            .info
+            .best_move
+            .expect("No best move found during search!");
+        let best_move = board
+            .find_move("f6f7")
+            .expect("Move not found in legal moves!");
+
+        assert_eq!(search_move, best_move);
+        board.make_move(best_move);
+
+        let best_move = board
+            .find_move("c5d6")
+            .expect("Move not found in legal moves!");
+        board.make_move(best_move);
+
+        let best_move_queen = board
+            .find_move("f7f8q")
+            .expect("Move not found in legal moves!");
+
+        let best_move_bishop = board
+            .find_move("f7f8b")
+            .expect("Move not found in legal moves!");
+
+        search = Search::new(&board, None);
+        search.search(&SimpleEvaluator, Some(Depth::MAX));
+        let search_move = search
+            .info
+            .best_move
+            .expect("No best move found during search!");
+        assert!(
+            search_move == best_move_queen || search_move == best_move_bishop,
+            "Search found {search_move} was the best move, but the best move was {best_move_queen} or {best_move_bishop}"
+        );
     }
 
     #[test]

--- a/src/search/info.rs
+++ b/src/search/info.rs
@@ -3,7 +3,7 @@ use crate::board::Ply;
 use super::{Depth, Score};
 
 pub const MAX_KILLERS: usize = 2;
-pub type KillerList = [[Option<Ply>; MAX_KILLERS]; Depth::MAX as usize];
+pub type KillerList = [[Option<Ply>; MAX_KILLERS]; Depth::MAX as usize + 1];
 
 /// Information about the search process.
 /// Usually displayed in the uci `info` log.
@@ -47,7 +47,7 @@ impl Info {
             best_score: None,
             nodes: 0,
             depth: 0,
-            killers: [[None; MAX_KILLERS]; Depth::MAX as usize],
+            killers: [[None; MAX_KILLERS]; Depth::MAX as usize + 1],
         }
     }
 }


### PR DESCRIPTION
Fix index out of bounds error and an integer overflow error near the end of the game. When the game is at a mate in one, and we had previously searched the board at a mate-in-two position, we had an error where the search would run to the maximum depth and then try to access the killers board out of bounds. This fixes this issue and the issue of overflowing our depth on long searches

This seems to slightly slow things down, but this is an important fix. The slowdown is almost certainly related to the extra checks in `check_limits`

Bench: 13749273