### PR TITLE
Enable lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ strum_macros = "0.26.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Enables advanced optimizations in the release profile that should lead to large speedups at the expense of compile time.

Bench: 13749273