### PR TITLE
Use one codegen unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ pretty_assertions = "1.4.0"
 
 [profile.release]
 lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Don't split the rust project up into multiple parts that can be compiled in parallel. Instead, compile as one large unit. This can potentially speed things up more, but at the cost of compile time.

Bench: 13749273