### PR TITLE
Remove depth checking from limits

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -551,12 +551,6 @@ impl Search {
                 return true;
             }
         }
-        if let Some(depth) = self.limits.depth {
-            if self.info.depth >= depth {
-                self.running.store(false, Ordering::Relaxed);
-                return true;
-            }
-        }
         if let Some(movetime) = self.limits.movetime {
             if start.elapsed().as_millis() >= movetime {
                 self.running.store(false, Ordering::Relaxed);


### PR DESCRIPTION
Depth checking is handled in iterdeep, so it's unnecessary to check it in check limits. Additionally, this would end up producing bugs where quiescence search would run into the depth limit and then prematurely bail.

Bench: 13749273