### PR TITLE
Check termination

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -320,9 +320,11 @@ impl Search {
         mut depth: Depth,
         start: Instant,
     ) -> Score {
-        if self.info.nodes & CHECK_TERMINATION == 0
-            && (!self.is_running() || self.limits_exceeded(start))
-        {
+        if self.info.nodes & CHECK_TERMINATION == 0 {
+            self.limits_exceeded(start);
+        }
+
+        if !self.is_running() {
             return 0;
         }
 
@@ -488,9 +490,11 @@ impl Search {
         beta_start: Score,
         start: Instant,
     ) -> Score {
-        if self.info.nodes & CHECK_TERMINATION == 0
-            && (!self.is_running() || self.limits_exceeded(start))
-        {
+        if self.info.nodes & CHECK_TERMINATION == 0 {
+            self.limits_exceeded(start);
+        }
+
+        if !self.is_running() {
             return 0;
         }
 
@@ -564,18 +568,8 @@ impl Search {
     /// let limits_exceeded = search.check_limits();
     /// ```
     fn limits_exceeded(&self, start: Instant) -> bool {
-        if self.info.depth == Depth::MAX {
-            self.stop();
-            return true;
-        }
         if let Some(nodes) = self.limits.nodes {
             if self.info.nodes >= nodes {
-                self.stop();
-                return true;
-            }
-        }
-        if let Some(movetime) = self.limits.movetime {
-            if start.elapsed().as_millis() >= movetime {
                 self.stop();
                 return true;
             }
@@ -640,13 +634,13 @@ impl Search {
         };
 
         let time_str = match time_elapsed_in_ms {
-            Some(time) if time > 0 => format!("time {time}"),
+            Some(time) if time > 0 => format!(" time {time}"),
             _ => String::new(),
         };
         let node_str = format!("nodes {}", self.info.nodes);
         let nps_str = match time_elapsed_in_ms {
             Some(time) if time > 0 => {
-                format!("nps {}", (self.info.nodes * 1000) / (time as u64))
+                format!(" nps {}", (self.info.nodes * 1000) / (time as u64))
             }
             _ => String::new(),
         };
@@ -654,7 +648,7 @@ impl Search {
         let pv_string = pv_notation.join(" ");
 
         self.log(
-            format!("info {depth_str} {node_str} {time_str} {nps_str} {score_str} pv {pv_string}")
+            format!("info {depth_str} {node_str}{time_str}{nps_str} {score_str} pv {pv_string}")
                 .as_str(),
         );
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -567,7 +567,7 @@ impl Search {
     /// let mut search = Search::new(&board, &evaluator, None);
     /// let limits_exceeded = search.check_limits();
     /// ```
-    fn limits_exceeded(&self, start: Instant) -> bool {
+    fn limits_exceeded(&mut self, start: Instant) -> bool {
         if let Some(nodes) = self.limits.nodes {
             if self.info.nodes >= nodes {
                 self.stop();
@@ -768,11 +768,14 @@ impl Search {
     /// search.stop();
     /// assert_eq!(search.is_running(), false);
     /// ```
-    pub fn stop(&self) {
+    pub fn stop(&mut self) {
         self.running.store(false, Ordering::Relaxed);
+        self.info.terminated = true;
     }
 
     /// Returns a boolean determining if the search is still running
+    ///
+    /// Uses a copy of the `AtomicBool` to determine if the search is still running, leading to some speedups.
     ///
     /// # Returns
     ///
@@ -785,8 +788,8 @@ impl Search {
     /// let mut search = Search::new(&board, &evaluator, None);
     /// let running = search.check_running();
     /// ```
-    pub fn is_running(&self) -> bool {
-        self.running.load(Ordering::Relaxed)
+    pub const fn is_running(&self) -> bool {
+        !self.info.terminated
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -567,7 +567,7 @@ impl Search {
     /// let mut search = Search::new(&board, &evaluator, None);
     /// let limits_exceeded = search.check_limits();
     /// ```
-    fn limits_exceeded(&mut self, start: Instant) -> bool {
+    fn limits_exceeded(&self, start: Instant) -> bool {
         if let Some(nodes) = self.limits.nodes {
             if self.info.nodes >= nodes {
                 self.stop();
@@ -768,14 +768,11 @@ impl Search {
     /// search.stop();
     /// assert_eq!(search.is_running(), false);
     /// ```
-    pub fn stop(&mut self) {
+    pub fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
-        self.info.terminated = true;
     }
 
     /// Returns a boolean determining if the search is still running
-    ///
-    /// Uses a copy of the `AtomicBool` to determine if the search is still running, leading to some speedups.
     ///
     /// # Returns
     ///
@@ -788,8 +785,8 @@ impl Search {
     /// let mut search = Search::new(&board, &evaluator, None);
     /// let running = search.check_running();
     /// ```
-    pub const fn is_running(&self) -> bool {
-        !self.info.terminated
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
     }
 }
 

--- a/src/search/info.rs
+++ b/src/search/info.rs
@@ -38,7 +38,6 @@ pub struct Info {
     pub depth: Depth,
     pub seldepth: Depth,
     pub killers: KillerList,
-    pub terminated: bool,
 }
 
 impl Info {
@@ -51,7 +50,6 @@ impl Info {
             depth: 0,
             seldepth: 0,
             killers: [[None; MAX_KILLERS]; Depth::MAX as usize + 1],
-            terminated: false,
         }
     }
 }

--- a/src/search/info.rs
+++ b/src/search/info.rs
@@ -38,6 +38,7 @@ pub struct Info {
     pub depth: Depth,
     pub seldepth: Depth,
     pub killers: KillerList,
+    pub terminated: bool,
 }
 
 impl Info {
@@ -50,6 +51,7 @@ impl Info {
             depth: 0,
             seldepth: 0,
             killers: [[None; MAX_KILLERS]; Depth::MAX as usize + 1],
+            terminated: false,
         }
     }
 }


### PR DESCRIPTION
Avoid timeout on search cancellation
Checks timeout on each loop, while checking conditions for timeout every 2000 or so moves.

Bench: 13749273